### PR TITLE
handle error waiting for localstack to start

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -22,8 +22,11 @@ datasets_location = os.getenv("MOCK_EXPERIMENT_DATA_PATH")
 
 environment = "development"
 
-@backoff.on_exception(backoff.expo, Exception, max_time=20)
+@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_time=20)
 def wait_for_localstack():
+    logger.info(
+        "Waiting for localstack to spin up..."
+    )
     requests.get("http://localstack:4566")
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -22,7 +22,7 @@ datasets_location = os.getenv("MOCK_EXPERIMENT_DATA_PATH")
 
 environment = "development"
 
-@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_time=20)
+@backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_time=60)
 def wait_for_localstack():
     logger.info(
         "Waiting for localstack to spin up..."


### PR DESCRIPTION
## Background

Sometimes `inframock-service` runs faster than `localstack`, causing GET request in `wait_for_localstack()` to throw exception. The exception is not handled, which causes `inframock-service` to exit with code 1. To remedy this, inframock service has to be restarted, during which after the restart, the `localstack` service spins up more quickly than `inframock-service`, and the service runs.

## Code changes

The proposed change handles the exception in `backoff`, forching retry. Aside from that, it also emits a nice info to the user.

![image](https://user-images.githubusercontent.com/2862362/104042993-bf272c00-520d-11eb-9a6f-8b043efbd5f7.png)
