### PR TITLE
Use decimals in place of strings in InfraMock

### DIFF
--- a/mock_experiment.json
+++ b/mock_experiment.json
@@ -1663,8 +1663,8 @@
           "method": "absolute_threshold",
           "methodSettings" : {
             "absolute_threshold" : {
-              "maxFraction": "0.1",
-              "binStep": "0.05"
+              "maxFraction": 0.1,
+              "binStep": 0.05
             }
           }
         }
@@ -1675,8 +1675,8 @@
           "method": "absolute_threshold",
           "methodSettings" : {
             "absolute_threshold" : {
-              "filterThreshold": "0.5",
-              "bandwidth": "-1"
+              "filterThreshold": 0.5,
+              "bandwidth": -1
             }
           }
         }
@@ -1684,8 +1684,8 @@
       "classifier": {
         "enabled": true,
         "filterSettings": {
-          "minProbabiliy": "0.8",
-          "filterThreshold": "-1"
+          "minProbabiliy": 0.8,
+          "filterThreshold": -1
         }
       },
       "numGenesVsNumUmis": {
@@ -1693,17 +1693,17 @@
         "filterSettings": {
           "regressionType": "gam",
           "smoothing": 13,
-          "upperCutoff": "4.8",
-          "lowerCutoff": "2.1",
-          "stringency": "2.1",
-          "binStep": "0.05"
+          "upperCutoff": 4.8,
+          "lowerCutoff": 2.1,
+          "stringency": 2.1,
+          "binStep": 0.05
         }
       },
       "doubletScores": {
         "enabled": true,
         "filterSettings": {
-          "probabilityThreshold": "0.2",
-          "binStep": "0.05"
+          "probabilityThreshold": 0.2,
+          "binStep": 0.05
         }
       },
       "dimensionalityReduction": {
@@ -1725,7 +1725,7 @@
           "method": "umap",
           "methodSettings": {
             "umap" : {
-              "minimumDistance" : "0.1",
+              "minimumDistance" : 0.1,
               "distanceMetric": "euclidean"
             },
             "tsne": {
@@ -1738,7 +1738,7 @@
           "method": "louvain",
           "methodSettings": {
             "louvain" : {
-              "resolution": "0.5"
+              "resolution": 0.5
             }
           }
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ boto3
 requests
 backoff
 cfn_flip
+simplejson

--- a/src/app.py
+++ b/src/app.py
@@ -3,7 +3,7 @@ import requests
 import backoff
 import logging
 import sys
-import json
+import simplejson as json
 import gzip
 import os
 from pathlib import Path
@@ -61,7 +61,7 @@ def provision_biomage_stack():
 
 def populate_mock_dynamo():
     with open('mock_experiment.json') as json_file:
-        experiment_data = json.load(json_file)
+        experiment_data = json.load(json_file, use_decimal=True)
 
     dynamo = boto3.resource('dynamodb', endpoint_url="http://localstack:4566")
     table = dynamo.Table("experiments-{}".format(environment))


### PR DESCRIPTION
This allows us to use `Decimal`-typed numbers instead of strings for numeric parameters. This is required so OpenAPI passes validation on experiment settings.