### PR TITLE
Remove reference to Dashboard from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 inframock
 =========
 
-InfraMock is a local copy of the Biomage AWS stack for development purposes. It uses localstack to
-create a mocked version of our AWS stack. It can also, optionally, populate this stack with real data
-if local development is desired.
+InfraMock is a local copy of the Biomage AWS stack for development purposes. It uses
+[localstack](https://github.com/localstack/localstack) to create a mocked version of our AWS stack.
+It can also, optionally, populate this stack with real data if local development is desired.
 
 How to use it
 -------------
@@ -20,11 +20,11 @@ You may want to use some additional environment variables. See the section down 
 
 What's included
 ---------------
-The following servies are running within InfraMock:
+
+The following services are running within InfraMock:
 
 * A Redis instance accessible from host port `6379`.
 * An AWS-compatible endpoint accessible from host port `4566`.
-* A (pretty crappy) dashboard for said AWS-compatible endpoint running on port `8055`.
 
 The endpoint on port `4566` is a drop-in replacement for the default AWS endpoint for a given
 region. It has a working version of SQS, SNS, S3 and DynamoDB running. Services are configured
@@ -36,15 +36,15 @@ Environment variables
 The following environment variables are exposed for InfraMock:
 
 `POPULATE_MOCK`: whether localstack should be filled with a mocked PBMC data set. This is
-set to `true` by default, which means that InfraMock will try to use a locally running version of 
-the `api` to populate the localstack DynamoDB database with using its `/experiments/generate` endpoint. 
+set to `true` by default, which means that InfraMock will try to use a locally running version of
+the `api` to populate the localstack DynamoDB database with using its `/experiments/generate` endpoint.
 For this to work, `api` **must** be running with `CLUSTER_ENV` set to `development`, which is the default behavior.
 
 `MOCK_EXPERIMENT_DATA_PATH`: where to get the mocked data for upload to the local S3 from. If
 this is not set, it will default to the Github URL where the dataset used for the `worker` unit
 test is located.
 
-`AWS_DEFAULT_REGION`: the default mocked region for your infrastructure to be deployed under. If it's not set, 
+`AWS_DEFAULT_REGION`: the default mocked region for your infrastructure to be deployed under. If it's not set,
 it defaults to `eu-west-1`.
 
 FAQ
@@ -52,7 +52,7 @@ FAQ
 
 **Q: I want to directly access the AWS resources in InfraMock. How do I do this?**
 
-A: The easiest way is to use the `aws-cli` along with Inframock on a separate terminal.
+A: The easiest way is to use the `aws-cli` along with InfraMock on a separate terminal.
 You can add `--endpoint-url` as the *second* argument to
 `aws`, which will automatically redirect all further requests to InfraMock. For example:
 
@@ -65,4 +65,4 @@ will give you the following output:
 
 You can also use tools like [medis](https://github.com/luin/medis) for interactively debugging the local
 Redis cache, and [NoSQL Workbench](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.html)
-to inspect and modify the current state of the local DynamoDB instance.
+to inspect and modify the current state of the local DynamoDB instance (`Operation Builder -> Add Connection`).


### PR DESCRIPTION
The _(pretty crappy) dashboard for said AWS-compatible endpoint_ is not exposed in our `docker-compose` files any more. There is also a bit of Markdown linting and other minor changes.