### PR TITLE
Fix for inframock in online mode

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -129,9 +129,7 @@ def populate_mock_s3(experiment_id):
 
                 logger.debug(f"Downloaded {f}, now uploading to S3 as {key} ...")
                 s3 = boto3.resource("s3", endpoint_url="http://localstack:4566")
-
-                s3.Object(find_biomage_source_bucket_name(),
-                          f"{experiment_id}/{Path(f).stem}").upload_fileobj(Fileobj=contents, Config=config)
+                s3.Object(find_biomage_source_bucket_name(), f"{experiment_id}/{Path(f).stem}").put(Body=contents.read())
 
     logger.info("Mocked experiment data successfully uploaded to S3.")
 


### PR DESCRIPTION
Rolled back some changes in order for inframock to work both with local data and data from the worker repo in data/tests. 

-Tested it in my environment with the current data/tests/r.rds.gz file and it works. 

Inframock doesn't have a PR template but here's my cute animal picture:

![image](https://user-images.githubusercontent.com/76957896/110113893-867d7c00-7d92-11eb-8a7c-e0aba92d4225.png)
