### PR TITLE
Fix multipart upload for s3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       - MAIN_CONTAINER_NAME='biomage-inframock-localstack'
       - LAMBDA_EXECUTOR=local
       - EXTRA_CORS_ALLOWED_HEADERS=amz-sdk-request, amz-sdk-invocation-id
+      - EXTRA_CORS_EXPOSE_HEADERS=Etag
     privileged: true
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
Expose Etag header so taht multipart uploads from amplify can be compelted correctly, this might need to be configured in the real s3's too