### PR TITLE
readded separate files for linux & mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,13 @@
 # Variables
 #--------------------------------------------------
 PYTHON_FILES?=$$(find python -name '*.py')
+# If unix name is Darwin, we are in MacOS => use regular docker-compose.yaml
+# Otherwise assume Linux and add docker-compose.linux-dev.yaml overrides
+ifeq ($(shell uname -s), Darwin)
+  docker_files=-f docker-compose.yaml
+else
+  docker_files=-f docker-compose.yaml -f docker-compose.linux-dev.yaml
+endif
 #--------------------------------------------------
 # Targets
 #--------------------------------------------------
@@ -22,12 +29,12 @@ check: ## Checks code for linting/construct errors
 	@echo "    [✓]\n"
 build: ## Builds the docker-compose environment
 	@echo "==> Building docker image..."
-	@docker-compose build
+	@docker-compose $(docker_files) build
 	@echo "    [✓]\n"
-run: ## Runs the docker environment
-	@docker-compose up
+run: build ## Runs the docker environment
+	@docker-compose $(docker_files) up
 reload-data: ## Reloads the input data found in ./data. NOTE: it will not remove from s3 & dynamo generated data like processed matrices, or plots. If you need a clean start, stop & re-run inframock.
-	@docker-compose  up -d --no-deps --build service
+	@docker-compose $(docker_files)  up -d --no-deps --build service
 .PHONY: bootstrap fmt check build run clean help
 clean: ## Cleans up temporary files
 	@echo "==> Cleaning up ..."

--- a/docker-compose.linux-dev.yaml
+++ b/docker-compose.linux-dev.yaml
@@ -1,0 +1,5 @@
+version: "3.2"
+services:
+  localstack:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,8 +32,6 @@ services:
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "~/.docker:/root/.docker"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
   service:
     container_name: "biomage-inframock-service"
     build: .

--- a/src/app.py
+++ b/src/app.py
@@ -31,7 +31,7 @@ CELL_SETS_BUCKET_NAME = "cell-sets-development"
 MB = 1024 ** 2
 config = TransferConfig(multipart_threshold=20 * MB)
 
-dynamodb_mocks = ["mock_experiment.json", "mock_samples.json"]
+dynamodb_mocks = ["mock_experiment.json", "mock_samples.json", "mock_plots_tables.json"]
 
 
 @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_time=60)
@@ -125,7 +125,7 @@ def update_dynamoDB(f):
         dynamo = boto3.resource("dynamodb", endpoint_url=LOCALSTACK_ENDPOINT)
         table = dynamo.Table("{}-{}".format(table_name, ENVIROMENT))
 
-        if data.get("records"):
+        if "records" in data:
             for data_item in data["records"]:
                 table.put_item(Item=data_item)
         else:


### PR DESCRIPTION
having a single dockerfile seems to be causing issues for some mac users while it works for others (different `docker-compose` version?) . I'm reverting to having different files as it is causing more issues than it solves.

The issue is outdated docker version see: https://blog.adamzolo.com/dockerizing-mariadb-with-a-custom-sql-script-in-development/