### PR TITLE
Allow cellranger_version metadata header in s3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
       - DOCKER_HOST=unix:///var/run/docker.sock
       - MAIN_CONTAINER_NAME='biomage-inframock-localstack'
       - LAMBDA_EXECUTOR=local
-      - EXTRA_CORS_ALLOWED_HEADERS=amz-sdk-request, amz-sdk-invocation-id
+      - EXTRA_CORS_ALLOWED_HEADERS=amz-sdk-request, amz-sdk-invocation-id, x-amz-meta-cellranger_version
       - EXTRA_CORS_EXPOSE_HEADERS=Etag
     privileged: true
     volumes:


### PR DESCRIPTION
Add x-amz-meta-cellranger_version to allowed headers.
This way we can send metadata about file version when uploading genes/features file.