### PR TITLE
[BIOMAGE-1101] Upgrade localstack and boto3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       - "6379:6379"
   localstack:
     container_name: "biomage-inframock-localstack"
-    image: "localstack/localstack:0.12.8"
+    image: "localstack/localstack:0.12.12"
     ports:
       # forward out edge port. set boto3's `endpoint_url`
       # to be http://localhost:4566 to use localstack for development

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.17.82
+boto3==1.17.97
 requests==2.25.1
 backoff==1.10.0
 cfn-flip==1.2.3


### PR DESCRIPTION
# Background
#### Link to issue
https://biomage.atlassian.net/browse/BIOMAGE-1101
#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
To test:

1) With inframock running, start the pipeline. Check if you see a traceback culminating in `AttributeError: 'NoneType' object has no attribute 'set_stack_status'`. Making this not happen this is the objective of this PR.

2) Check that the upgrades didn't break anything on your system. `make run` on this branch and run the platform like you usually would. Check that nothing blows up.

# Changes
### Code changes
Upgraded localstack to 0.12.12 from 0.12.8. I can't immediately see anything in the release notes but this stops the above error from occurring when the pipeline is started.

Upgraded boto3 to 1.17.97 from 1.17.82. I initially did this as a first attempt to stop the error, but since it didn't break anything I thought I might as well keep it. All the other dependencies are already up to date.